### PR TITLE
Allow for more dofs (more bodies) in MD call

### DIFF
--- a/MoorDyn_caller.m
+++ b/MoorDyn_caller.m
@@ -1,8 +1,8 @@
 % function to return any items of interest to coupling from MoorDyn at
 % every time step
 function FLines = MoorDyn_caller(X,XD,Time,CoupTime)
-    FLines_value = zeros(1,6);
-    FLines = zeros(1,6);
+    FLines_value = zeros(1,length(X));
+    FLines = zeros(1,length(X));
     FLines_p = libpointer('doublePtr',FLines_value);
     calllib('libmoordyn', 'MoorDynStep', X, XD, FLines_p, Time, CoupTime);
     FLines = FLines_p.value;


### PR DESCRIPTION
This PR updates the MoorDyn call to use the length of the displacement vector as initialization for the force vector. This means that the mooring force should be initialized according to the number of MoorDyn connections in the model. This should resolve Issues [1432](https://github.com/WEC-Sim/WEC-Sim/discussions/1432) and [1440](https://github.com/WEC-Sim/WEC-Sim/issues/1440). 